### PR TITLE
War lives

### DIFF
--- a/.idea/dictionaries/dario.xml
+++ b/.idea/dictionaries/dario.xml
@@ -1,0 +1,8 @@
+<component name="ProjectDictionaryState">
+  <dictionary name="dario">
+    <words>
+      <w>warchest</w>
+      <w>warlives</w>
+    </words>
+  </dictionary>
+</component>

--- a/.idea/dictionaries/dario.xml
+++ b/.idea/dictionaries/dario.xml
@@ -1,6 +1,7 @@
 <component name="ProjectDictionaryState">
   <dictionary name="dario">
     <words>
+      <w>cremaining</w>
       <w>warchest</w>
       <w>warlives</w>
     </words>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.unitedlands</groupId>
   <artifactId>UnitedWar</artifactId>
-  <version>0.1</version>
+  <version>0.1-WARLIVES-SNAPSHOT1</version>
   <name>UnitedWar</name>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.unitedlands</groupId>
   <artifactId>UnitedWar</artifactId>
-  <version>0.1-WARLIVES-SNAPSHOT3</version>
+  <version>0.1-WARLIVES-SNAPSHOT4</version>
   <name>UnitedWar</name>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.unitedlands</groupId>
   <artifactId>UnitedWar</artifactId>
-  <version>0.1-WARLIVES-SNAPSHOT2</version>
+  <version>0.1-WARLIVES-SNAPSHOT3</version>
   <name>UnitedWar</name>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.unitedlands</groupId>
   <artifactId>UnitedWar</artifactId>
-  <version>0.1-WARLIVES-SNAPSHOT1</version>
+  <version>0.1-WARLIVES-SNAPSHOT2</version>
   <name>UnitedWar</name>
 
   <properties>

--- a/src/main/java/org/unitedlands/UnitedWar.java
+++ b/src/main/java/org/unitedlands/UnitedWar.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 
 import com.palmergames.bukkit.towny.scheduling.TaskScheduler;
 import com.palmergames.bukkit.towny.scheduling.impl.BukkitTaskScheduler;
+import org.unitedlands.util.WarLivesMetadata;
 
 public class UnitedWar extends JavaPlugin {
 
@@ -58,7 +59,14 @@ public class UnitedWar extends JavaPlugin {
         try {
             TownyAPI.getInstance().registerCustomDataField(MobilisationMetadata.MOBILISATION_FIELD);
         } catch (KeyAlreadyRegisteredException e) {
-            getLogger().warning(e.getMessage()); // A flag with the same key name already exists try again
+            getLogger().warning(e.getMessage());
+        }
+
+        // Try to register the war lives data field.
+        try {
+            TownyAPI.getInstance().registerCustomDataField(WarLivesMetadata.WARLIVES_FIELD);
+        } catch (KeyAlreadyRegisteredException e) {
+            getLogger().warning(e.getMessage());
         }
 
         getLogger().info("Flag successfully registered!");

--- a/src/main/java/org/unitedlands/UnitedWar.java
+++ b/src/main/java/org/unitedlands/UnitedWar.java
@@ -62,13 +62,6 @@ public class UnitedWar extends JavaPlugin {
             getLogger().warning(e.getMessage());
         }
 
-        // Try to register the war lives data field.
-        try {
-            TownyAPI.getInstance().registerCustomDataField(WarLivesMetadata.WARLIVES_FIELD);
-        } catch (KeyAlreadyRegisteredException e) {
-            getLogger().warning(e.getMessage());
-        }
-
         getLogger().info("Flag successfully registered!");
 
         getLogger().info("UnitedWar initialized.");

--- a/src/main/java/org/unitedlands/commands/WarDebugCommands.java
+++ b/src/main/java/org/unitedlands/commands/WarDebugCommands.java
@@ -261,7 +261,9 @@ public class WarDebugCommands implements CommandExecutor, TabCompleter {
             return;
         }
 
-        plugin.getWarManager().createWar("Debug War", "Debug War Description",
+        int random = (int) (Math.random() * 10000);
+        String title = "Debug_War_" + random;
+        plugin.getWarManager().createWar(title, "Debug War Description",
                 attackerTown.getUUID().toString(), defenderTown.getUUID().toString(), WarGoal.DEFAULT);
     }
 

--- a/src/main/java/org/unitedlands/listeners/PlayerDeathListener.java
+++ b/src/main/java/org/unitedlands/listeners/PlayerDeathListener.java
@@ -1,5 +1,6 @@
 package org.unitedlands.listeners;
 
+import com.palmergames.bukkit.towny.TownyUniverse;
 import org.bukkit.entity.Arrow;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Fireball;
@@ -19,6 +20,10 @@ import org.unitedlands.classes.WarSide;
 import org.unitedlands.events.WarScoreEvent;
 
 import com.palmergames.bukkit.towny.TownyAPI;
+import org.unitedlands.util.Messages;
+import org.unitedlands.util.WarLivesMetadata;
+
+import java.util.UUID;
 
 public class PlayerDeathListener implements Listener {
 
@@ -76,6 +81,32 @@ public class PlayerDeathListener implements Listener {
                         WarSide.DEFENDER, warScoreType, reward);
                 warScoreEvent.callEvent();
             }
+            var resident = TownyUniverse.getInstance().getResident(victim.getUniqueId());
+            if (resident != null) {
+                for (var warEntry : victimWars.entrySet()) {
+                    var war = warEntry.getKey();
+                    UUID warId = war.getId();
+                    int currentLives = WarLivesMetadata.getWarLivesMetaData(resident, warId);
+                    int newLives = Math.max(0, currentLives - 1);
+                    WarLivesMetadata.setWarLivesMetaData(resident, warId, newLives);
+
+                    String warName = plugin.getWarManager().getWarTitle(warId);
+
+                    if (currentLives == 0) {
+                        // Already out of lives.
+                        victim.sendMessage(Messages.getMessage("warlives-gone"));
+                    } else if (newLives == 0) {
+                        // Just lost final life.
+                        victim.sendMessage(Messages.getMessage("warlives-final")
+                                .replaceText(t -> t.matchLiteral("{0}").replacement(warName)));
+                    } else {
+                        // Still has lives left.
+                        victim.sendMessage(Messages.getMessage("warlives-lost")
+                                .replaceText(t -> t.matchLiteral("{0}").replacement(String.valueOf(newLives)))
+                                .replaceText(t -> t.matchLiteral("{1}").replacement(warName)));
+                    }
+                }
+            }
         }
 
     }
@@ -90,24 +121,21 @@ public class PlayerDeathListener implements Listener {
         }
 
         // Arrow shot by player
-        else if (damager instanceof Arrow) {
-            Arrow arrow = (Arrow) damager;
+        else if (damager instanceof Arrow arrow) {
             if (arrow.getShooter() instanceof Player) {
                 killer = (Player) arrow.getShooter();
             }
         }
 
         // Trident thrown by player
-        else if (damager instanceof Trident) {
-            Trident trident = (Trident) damager;
+        else if (damager instanceof Trident trident) {
             if (trident.getShooter() instanceof Player) {
                 killer = (Player) trident.getShooter();
             }
         }
 
         // TNT placed by player
-        else if (damager instanceof TNTPrimed) {
-            TNTPrimed tnt = (TNTPrimed) damager;
+        else if (damager instanceof TNTPrimed tnt) {
             if (tnt.getSource() instanceof Player) {
                 killer = (Player) tnt.getSource();
             }
@@ -115,24 +143,21 @@ public class PlayerDeathListener implements Listener {
 
         // Fireball launched by player
         // TODO: Fix this, it doesn't work with fireballs launched by players
-        else if (damager instanceof Fireball) {
-            Fireball fireball = (Fireball) damager;
+        else if (damager instanceof Fireball fireball) {
             if (fireball.getShooter() instanceof Player) {
                 killer = (Player) fireball.getShooter();
             }
         }
 
         // Thrown potion by player
-        else if (damager instanceof ThrownPotion) {
-            ThrownPotion potion = (ThrownPotion) damager;
+        else if (damager instanceof ThrownPotion potion) {
             if (potion.getShooter() instanceof Player) {
                 killer = (Player) potion.getShooter();
             }
         }
 
         // Wolf tamed by player
-        else if (damager instanceof Wolf) {
-            Wolf wolf = (Wolf) damager;
+        else if (damager instanceof Wolf wolf) {
             if (wolf.isTamed() && wolf.getOwner() instanceof Player) {
                 killer = (Player) wolf.getOwner();
             }

--- a/src/main/java/org/unitedlands/managers/WarManager.java
+++ b/src/main/java/org/unitedlands/managers/WarManager.java
@@ -369,6 +369,23 @@ public class WarManager implements Listener {
 
     //#region Public utility functions
 
+    // Get war title for display in /res screen.
+    public String getWarTitle(UUID warId) {
+        var pendingWar = pendingWars.stream()
+                .filter(w -> w.getId().equals(warId))
+                .findFirst().orElse(null);
+        if (pendingWar != null)
+            return pendingWar.getTitle();
+
+        var activeWar = activeWars.stream()
+                .filter(w -> w.getId().equals(warId))
+                .findFirst().orElse(null);
+        if (activeWar != null)
+            return activeWar.getTitle();
+
+        return "(Unknown War)";
+    }
+
     public War getWarByName(String name) {
         List<War> allWars = new ArrayList<War>();
         allWars.addAll(activeWars);
@@ -442,6 +459,8 @@ public class WarManager implements Listener {
         war.setState_changed(true);
     }
 
+    //#endregion
+
     private void assignWarLivesToParticipants(War war) {
         List<String> allPlayerIds = new ArrayList<>();
         allPlayerIds.addAll(war.getAttacking_players());
@@ -452,7 +471,7 @@ public class WarManager implements Listener {
                 UUID uuid = UUID.fromString(uuidStr);
                 var resident = TownyUniverse.getInstance().getResident(uuid);
                 if (resident != null) {
-                    WarLivesMetadata.addWarLivesMetaDataToResident(resident);
+                    WarLivesMetadata.setWarLivesForWarMetaData(resident, war.getId(), 5);
                 }
             } catch (Exception e) {
                 plugin.getLogger().warning("Failed to assign war lives to resident UUID: " + uuidStr + " - " + e.getMessage());
@@ -470,13 +489,11 @@ public class WarManager implements Listener {
                 UUID uuid = UUID.fromString(uuidStr);
                 var resident = TownyUniverse.getInstance().getResident(uuid);
                 if (resident != null) {
-                    WarLivesMetadata.removeWarLivesMetaDataFromResident(resident);
+                    WarLivesMetadata.removeWarLivesFromWarMetaData(resident, war.getId());
                 }
             } catch (Exception e) {
                 plugin.getLogger().warning("Failed to assign war lives to resident UUID: " + uuidStr + " - " + e.getMessage());
             }
         }
     }
-
-    //#endregion
 }

--- a/src/main/java/org/unitedlands/managers/WarManager.java
+++ b/src/main/java/org/unitedlands/managers/WarManager.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import com.palmergames.bukkit.towny.TownyUniverse;
+import com.palmergames.bukkit.towny.object.Resident;
 import org.bukkit.Bukkit;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
@@ -462,37 +463,37 @@ public class WarManager implements Listener {
     //#endregion
 
     private void assignWarLivesToParticipants(War war) {
-        List<String> allPlayerIds = new ArrayList<>();
-        allPlayerIds.addAll(war.getAttacking_players());
-        allPlayerIds.addAll(war.getDefending_players());
+        List<String> allPlayers = new ArrayList<>();
+        allPlayers.addAll(war.getAttacking_players());
+        allPlayers.addAll(war.getDefending_players());
 
-        for (String uuidStr : allPlayerIds) {
+        for (String uuidStr : allPlayers) {
             try {
                 UUID uuid = UUID.fromString(uuidStr);
-                var resident = TownyUniverse.getInstance().getResident(uuid);
+                Resident resident = TownyUniverse.getInstance().getResident(uuid);
                 if (resident != null) {
-                    WarLivesMetadata.setWarLivesForWarMetaData(resident, war.getId(), 5);
+                    WarLivesMetadata.setWarLivesMetaData(resident, war.getId(), 5); // default lives
                 }
             } catch (Exception e) {
-                plugin.getLogger().warning("Failed to assign war lives to resident UUID: " + uuidStr + " - " + e.getMessage());
+                plugin.getLogger().warning("Failed to assign war lives to " + uuidStr + ": " + e.getMessage());
             }
         }
     }
 
     private void removeWarLivesFromParticipants(War war) {
-        List<String> allPlayerIds = new ArrayList<>();
-        allPlayerIds.addAll(war.getAttacking_players());
-        allPlayerIds.addAll(war.getDefending_players());
+        List<String> allPlayers = new ArrayList<>();
+        allPlayers.addAll(war.getAttacking_players());
+        allPlayers.addAll(war.getDefending_players());
 
-        for (String uuidStr : allPlayerIds) {
+        for (String uuidStr : allPlayers) {
             try {
                 UUID uuid = UUID.fromString(uuidStr);
-                var resident = TownyUniverse.getInstance().getResident(uuid);
+                Resident resident = TownyUniverse.getInstance().getResident(uuid);
                 if (resident != null) {
-                    WarLivesMetadata.removeWarLivesFromWarMetaData(resident, war.getId());
+                    WarLivesMetadata.removeWarLivesMetaData(resident, war.getId());
                 }
             } catch (Exception e) {
-                plugin.getLogger().warning("Failed to assign war lives to resident UUID: " + uuidStr + " - " + e.getMessage());
+                plugin.getLogger().warning("Failed to remove war lives from " + uuidStr + ": " + e.getMessage());
             }
         }
     }

--- a/src/main/java/org/unitedlands/util/WarLivesMetadata.java
+++ b/src/main/java/org/unitedlands/util/WarLivesMetadata.java
@@ -18,7 +18,7 @@ public class WarLivesMetadata {
     // Set war lives for a specific war.
     public static void setWarLivesMetaData(Resident res, UUID warId, int lives) {
         String key = getMetaKey(warId);
-        String label = "War Lives: " + org.unitedlands.UnitedWar.getInstance().getWarManager().getWarTitle(warId);
+        String label = "War Lives " + org.unitedlands.UnitedWar.getInstance().getWarManager().getWarTitle(warId);
 
         removeWarLivesMetaData(res, warId); // Remove old if present.
         IntegerDataField field = new IntegerDataField(key, lives, label);

--- a/src/main/java/org/unitedlands/util/WarLivesMetadata.java
+++ b/src/main/java/org/unitedlands/util/WarLivesMetadata.java
@@ -1,0 +1,62 @@
+package org.unitedlands.util;
+
+import com.palmergames.bukkit.towny.TownyUniverse;
+import com.palmergames.bukkit.towny.object.Resident;
+import com.palmergames.bukkit.towny.object.metadata.CustomDataField;
+import com.palmergames.bukkit.towny.object.metadata.IntegerDataField;
+
+public class WarLivesMetadata {
+
+    // War Lives datafield.
+    private static final String KEYNAME = "unitedwar_war_lives";
+    private static final int DEFAULTVAL = 5;
+    private static final String LABEL = "War Lives";
+    public static final IntegerDataField WARLIVES_FIELD = new IntegerDataField(KEYNAME, DEFAULTVAL, LABEL);
+
+    public static void addWarLivesMetaDataToResident(Resident r) {
+        if (!r.hasMeta(KEYNAME)) {
+            r.addMetaData(WARLIVES_FIELD.clone());
+            TownyUniverse.getInstance().getDataSource().saveResident(r);
+        }
+    }
+
+    // Fetch war life metadata for resident.
+    public static int getWarLivesMetaDataFromResident(Resident r) {
+        if (r.hasMeta(WARLIVES_FIELD.getKey())) {
+            CustomDataField<?> cdf = r.getMetadata(WARLIVES_FIELD.getKey());
+            if (cdf instanceof IntegerDataField idf) {
+
+                return idf.getValue();
+            }
+        }
+
+        // Return a default value.
+        return DEFAULTVAL;
+    }
+
+    // Update resident war lives metadata.
+    public static void updateWarLivesMetaDataForResident(Resident r, int updatedVal) {
+        if (r.hasMeta(WARLIVES_FIELD.getKey())) {
+            CustomDataField<?> cdf = r.getMetadata(WARLIVES_FIELD.getKey());
+            if (cdf instanceof IntegerDataField idf) {
+                // Update the value.
+                idf.setValue(updatedVal);
+                TownyUniverse.getInstance().getDataSource().saveResident(r);
+            }
+        }
+    }
+
+    // Remove resident war lives metadata.
+    public static void removeWarLivesMetaDataFromResident(Resident r) {
+        r.removeMetaData(WARLIVES_FIELD);
+        TownyUniverse.getInstance().getDataSource().saveResident(r);
+    }
+
+    // Set a resident's war lives.
+    public static void setWarLivesMetaDataForResident(Resident r, int percent) {
+        r.removeMetaData(KEYNAME);
+        r.addMetaData(new IntegerDataField(KEYNAME, percent, LABEL));
+        TownyUniverse.getInstance().getDataSource().saveResident(r);
+    }
+
+}

--- a/src/main/java/org/unitedlands/util/WarLivesMetadata.java
+++ b/src/main/java/org/unitedlands/util/WarLivesMetadata.java
@@ -2,8 +2,9 @@ package org.unitedlands.util;
 
 import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.object.Resident;
-import com.palmergames.bukkit.towny.object.metadata.CustomDataField;
-import com.palmergames.bukkit.towny.object.metadata.IntegerDataField;
+import com.palmergames.bukkit.towny.object.metadata.StringDataField;
+
+import java.util.*;
 
 public class WarLivesMetadata {
 
@@ -11,52 +12,115 @@ public class WarLivesMetadata {
     private static final String KEYNAME = "unitedwar_war_lives";
     private static final int DEFAULTVAL = 5;
     private static final String LABEL = "War Lives";
-    public static final IntegerDataField WARLIVES_FIELD = new IntegerDataField(KEYNAME, DEFAULTVAL, LABEL);
+    public static final StringDataField WARLIVES_FIELD = new StringDataField(KEYNAME, "", LABEL) {
+        @Override
+        public String getValue() {
+            if (super.getValue() == null || super.getValue().isEmpty()) return "None";
 
-    public static void addWarLivesMetaDataToResident(Resident r) {
-        if (!r.hasMeta(KEYNAME)) {
-            r.addMetaData(WARLIVES_FIELD.clone());
-            TownyUniverse.getInstance().getDataSource().saveResident(r);
-        }
-    }
-
-    // Fetch war life metadata for resident.
-    public static int getWarLivesMetaDataFromResident(Resident r) {
-        if (r.hasMeta(WARLIVES_FIELD.getKey())) {
-            CustomDataField<?> cdf = r.getMetadata(WARLIVES_FIELD.getKey());
-            if (cdf instanceof IntegerDataField idf) {
-
-                return idf.getValue();
+            StringBuilder builder = new StringBuilder();
+            String[] entries = super.getValue().split("#");
+            for (String entry : entries) {
+                String[] pair = entry.split(":");
+                if (pair.length != 2) continue;
+                try {
+                    UUID warId = UUID.fromString(pair[0]);
+                    int lives = Integer.parseInt(pair[1]);
+                    String warTitle = org.unitedlands.UnitedWar.getInstance().getWarManager().getWarTitle(warId);
+                    builder.append(lives).append(" (").append(warTitle).append("), ");
+                } catch (Exception ignored) {}
             }
-        }
 
-        // Return a default value.
-        return DEFAULTVAL;
+            if (builder.length() > 2)
+                builder.setLength(builder.length() - 2);
+
+            return builder.toString();
+        }
+    };
+
+    // Set war lives metadata for a specific war.
+    public static void setWarLivesForWarMetaData(Resident res, UUID warId, int lives) {
+        Map<UUID, Integer> livesMap = getWarLivesMapMetaData(res);
+        livesMap.put(warId, lives);
+        setWarLivesMapMetaData(res, livesMap);
     }
 
-    // Update resident war lives metadata.
-    public static void updateWarLivesMetaDataForResident(Resident r, int updatedVal) {
-        if (r.hasMeta(WARLIVES_FIELD.getKey())) {
-            CustomDataField<?> cdf = r.getMetadata(WARLIVES_FIELD.getKey());
-            if (cdf instanceof IntegerDataField idf) {
-                // Update the value.
-                idf.setValue(updatedVal);
-                TownyUniverse.getInstance().getDataSource().saveResident(r);
+    // Get war lives metadata for a specific war.
+    public static int getWarLivesForWarMetaData(Resident res, UUID warId) {
+        return getWarLivesMapMetaData(res).getOrDefault(warId, DEFAULTVAL);
+    }
+
+    // Remove metadata field entirely.
+    public static void removeWarLivesFromWarMetaData(Resident res, UUID warId) {
+        Map<UUID, Integer> livesMap = getWarLivesMapMetaData(res);
+        livesMap.remove(warId);
+        setWarLivesMapMetaData(res, livesMap);
+    }
+
+    // Get war lives metadata for all wars.
+    public static Map<UUID, Integer> getWarLivesMapMetaData(Resident res) {
+        if (!res.hasMeta(KEYNAME)) return new HashMap<>();
+
+        StringDataField field = (StringDataField) res.getMetadata(KEYNAME);
+        Map<UUID, Integer> map = new HashMap<>();
+        if (field == null || field.getValue() == null || field.getValue().isEmpty()) return map;
+
+        String[] entries = field.getValue().split("#");
+        for (String entry : entries) {
+            String[] pair = entry.split(":");
+            if (pair.length != 2) continue;
+            try {
+                UUID warId = UUID.fromString(pair[0]);
+                int lives = Integer.parseInt(pair[1]);
+                map.put(warId, lives);
+            } catch (Exception ignored) {}
+        }
+        return map;
+    }
+
+    // Set war lives metadata for all wars.
+    private static void setWarLivesMapMetaData(Resident res, Map<UUID, Integer> map) {
+        List<String> entries = new ArrayList<>();
+        for (Map.Entry<UUID, Integer> entry : map.entrySet()) {
+            entries.add(entry.getKey() + ":" + entry.getValue());
+        }
+
+        String serialized = String.join("#", entries);
+        res.removeMetaData(KEYNAME);
+
+        if (serialized.isEmpty()) {
+            // Don't re-add the metadata if the player is in no wars.
+            TownyUniverse.getInstance().getDataSource().saveResident(res);
+            return;
+        }
+
+        StringDataField field = new StringDataField(KEYNAME, serialized, LABEL) {
+            @Override
+            public String getValue() {
+                if (super.getValue() == null || super.getValue().isEmpty()) return "None";
+                StringBuilder builder = new StringBuilder();
+                String[] entries = super.getValue().split("#");
+                for (String entry : entries) {
+                    String[] pair = entry.split(":");
+                    if (pair.length != 2) continue;
+                    try {
+                        UUID warId = UUID.fromString(pair[0]);
+                        int lives = Integer.parseInt(pair[1]);
+                        String warTitle = org.unitedlands.UnitedWar.getInstance().getWarManager().getWarTitle(warId);
+                        builder.append(lives).append(" (").append(warTitle).append("), ");
+                    } catch (Exception ignored) {
+                    }
+                }
+                if (builder.length() > 2)
+                    builder.setLength(builder.length() - 2);
+                return builder.toString();
             }
-        }
+        };
+        res.addMetaData(field);
+        TownyUniverse.getInstance().getDataSource().saveResident(res);
     }
 
-    // Remove resident war lives metadata.
-    public static void removeWarLivesMetaDataFromResident(Resident r) {
-        r.removeMetaData(WARLIVES_FIELD);
-        TownyUniverse.getInstance().getDataSource().saveResident(r);
-    }
-
-    // Set a resident's war lives.
-    public static void setWarLivesMetaDataForResident(Resident r, int percent) {
-        r.removeMetaData(KEYNAME);
-        r.addMetaData(new IntegerDataField(KEYNAME, percent, LABEL));
-        TownyUniverse.getInstance().getDataSource().saveResident(r);
+    public static boolean isInWar(Resident res, UUID warId) {
+        return getWarLivesMapMetaData(res).containsKey(warId);
     }
 
 }

--- a/src/main/java/org/unitedlands/util/WarLivesMetadata.java
+++ b/src/main/java/org/unitedlands/util/WarLivesMetadata.java
@@ -2,125 +2,61 @@ package org.unitedlands.util;
 
 import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.object.Resident;
-import com.palmergames.bukkit.towny.object.metadata.StringDataField;
+import com.palmergames.bukkit.towny.object.metadata.IntegerDataField;
 
 import java.util.*;
 
+
 public class WarLivesMetadata {
+    private static final int DEFAULT_LIVES = 5;
 
-    // War Lives datafield.
-    private static final String KEYNAME = "unitedwar_war_lives";
-    private static final int DEFAULTVAL = 5;
-    private static final String LABEL = "War Lives";
-    public static final StringDataField WARLIVES_FIELD = new StringDataField(KEYNAME, "", LABEL) {
-        @Override
-        public String getValue() {
-            if (super.getValue() == null || super.getValue().isEmpty()) return "None";
-
-            StringBuilder builder = new StringBuilder();
-            String[] entries = super.getValue().split("#");
-            for (String entry : entries) {
-                String[] pair = entry.split(":");
-                if (pair.length != 2) continue;
-                try {
-                    UUID warId = UUID.fromString(pair[0]);
-                    int lives = Integer.parseInt(pair[1]);
-                    String warTitle = org.unitedlands.UnitedWar.getInstance().getWarManager().getWarTitle(warId);
-                    builder.append(lives).append(" (").append(warTitle).append("), ");
-                } catch (Exception ignored) {}
-            }
-
-            if (builder.length() > 2)
-                builder.setLength(builder.length() - 2);
-
-            return builder.toString();
-        }
-    };
-
-    // Set war lives metadata for a specific war.
-    public static void setWarLivesForWarMetaData(Resident res, UUID warId, int lives) {
-        Map<UUID, Integer> livesMap = getWarLivesMapMetaData(res);
-        livesMap.put(warId, lives);
-        setWarLivesMapMetaData(res, livesMap);
+    // Generate a unique metadata key per war.
+    private static String getMetaKey(UUID warId) {
+        return "unitedwar_war_lives_" + warId;
     }
 
-    // Get war lives metadata for a specific war.
-    public static int getWarLivesForWarMetaData(Resident res, UUID warId) {
-        return getWarLivesMapMetaData(res).getOrDefault(warId, DEFAULTVAL);
-    }
+    // Set war lives for a specific war.
+    public static void setWarLivesMetaData(Resident res, UUID warId, int lives) {
+        String key = getMetaKey(warId);
+        String label = "War Lives: " + org.unitedlands.UnitedWar.getInstance().getWarManager().getWarTitle(warId);
 
-    // Remove metadata field entirely.
-    public static void removeWarLivesFromWarMetaData(Resident res, UUID warId) {
-        Map<UUID, Integer> livesMap = getWarLivesMapMetaData(res);
-        livesMap.remove(warId);
-        setWarLivesMapMetaData(res, livesMap);
-    }
-
-    // Get war lives metadata for all wars.
-    public static Map<UUID, Integer> getWarLivesMapMetaData(Resident res) {
-        if (!res.hasMeta(KEYNAME)) return new HashMap<>();
-
-        StringDataField field = (StringDataField) res.getMetadata(KEYNAME);
-        Map<UUID, Integer> map = new HashMap<>();
-        if (field == null || field.getValue() == null || field.getValue().isEmpty()) return map;
-
-        String[] entries = field.getValue().split("#");
-        for (String entry : entries) {
-            String[] pair = entry.split(":");
-            if (pair.length != 2) continue;
-            try {
-                UUID warId = UUID.fromString(pair[0]);
-                int lives = Integer.parseInt(pair[1]);
-                map.put(warId, lives);
-            } catch (Exception ignored) {}
-        }
-        return map;
-    }
-
-    // Set war lives metadata for all wars.
-    private static void setWarLivesMapMetaData(Resident res, Map<UUID, Integer> map) {
-        List<String> entries = new ArrayList<>();
-        for (Map.Entry<UUID, Integer> entry : map.entrySet()) {
-            entries.add(entry.getKey() + ":" + entry.getValue());
-        }
-
-        String serialized = String.join("#", entries);
-        res.removeMetaData(KEYNAME);
-
-        if (serialized.isEmpty()) {
-            // Don't re-add the metadata if the player is in no wars.
-            TownyUniverse.getInstance().getDataSource().saveResident(res);
-            return;
-        }
-
-        StringDataField field = new StringDataField(KEYNAME, serialized, LABEL) {
-            @Override
-            public String getValue() {
-                if (super.getValue() == null || super.getValue().isEmpty()) return "None";
-                StringBuilder builder = new StringBuilder();
-                String[] entries = super.getValue().split("#");
-                for (String entry : entries) {
-                    String[] pair = entry.split(":");
-                    if (pair.length != 2) continue;
-                    try {
-                        UUID warId = UUID.fromString(pair[0]);
-                        int lives = Integer.parseInt(pair[1]);
-                        String warTitle = org.unitedlands.UnitedWar.getInstance().getWarManager().getWarTitle(warId);
-                        builder.append(lives).append(" (").append(warTitle).append("), ");
-                    } catch (Exception ignored) {
-                    }
-                }
-                if (builder.length() > 2)
-                    builder.setLength(builder.length() - 2);
-                return builder.toString();
-            }
-        };
+        removeWarLivesMetaData(res, warId); // Remove old if present.
+        IntegerDataField field = new IntegerDataField(key, lives, label);
         res.addMetaData(field);
         TownyUniverse.getInstance().getDataSource().saveResident(res);
     }
 
-    public static boolean isInWar(Resident res, UUID warId) {
-        return getWarLivesMapMetaData(res).containsKey(warId);
+    // Get current war lives for a specific war.
+    public static int getWarLivesMetaData(Resident res, UUID warId) {
+        String key = getMetaKey(warId);
+        if (!res.hasMeta(key)) return DEFAULT_LIVES;
+
+        var meta = res.getMetadata(key);
+        if (meta instanceof IntegerDataField field) {
+            return field.getValue();
+        }
+        return DEFAULT_LIVES;
     }
 
+    // Update war lives.
+    public static void updateWarLivesMetaData(Resident res, UUID warId, int newLives) {
+        String key = getMetaKey(warId);
+        if (!res.hasMeta(key)) return;
+
+        var meta = res.getMetadata(key);
+        if (meta instanceof IntegerDataField field) {
+            field.setValue(newLives);
+            res.addMetaData(field);
+            TownyUniverse.getInstance().getDataSource().saveResident(res);
+        }
+    }
+
+    // Remove metadata for a specific war.
+    public static void removeWarLivesMetaData(Resident res, UUID warId) {
+        String key = getMetaKey(warId);
+        if (!res.hasMeta(key)) return;
+
+        res.removeMetaData(key);
+        TownyUniverse.getInstance().getDataSource().saveResident(res);
+    }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -470,8 +470,14 @@ messages:
   # {0} is the town or nation name.
   # {1} is the war lives amount.
   # {2} is the war name.
-  warlives-set: "§e§l{0} §2war lives set to §e§l{1} §2in §e§l{2}"
+  warlives-set: "§e§l{0} §2war lives set to §e§l{1} §2in §e§l{2}§2."
   # {0} is the player username.
   # {1} is the war lives amount.
   # {2} is the war name.
-  warlives-get: "§e§l{0} §7has §e§l{1} §2lives in §e§l{2}"
+  warlives-get: "§e§l{0} §7has §e§l{1} §2lives in §e§l{2}§2."
+  # {0} is the amount of lives remaining.
+  # {1} is the name of the war.
+  warlives-lost: "§cYou died and lost a war life! You have §e§l{0} §cremaining in §e§l{1}§c."
+  # {0} is the name of the war.
+  warlives-final: "§cYou died and lost your final war life! You have been removed from §e§l{0}§c."
+  warlives-gone: "§cYou died but have already lost your final war life!"

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -401,6 +401,8 @@ messages:
   town-nation-not-found: "§2No town or nation found named §e§l{0}"
   # {0} is the attempted input.
   not-a-number: "§e§l{0} §2is not a number."
+  # {0} is the player username.
+  player-not-found: "§e§l{0} is not a recognised username or not online."
   invalid-mobilisation-number: "§2Mobilisation must be set between 0-100."
   # {0} is the town or nation name.
   # {1} is the mobilisation amount.
@@ -457,3 +459,14 @@ messages:
     - "§f{event-description}"
     - "§7This event has now ended and all effects have been removed"
     - "§c§m+|✦                  +✦+                  |✦+"
+# +---------------------------------------------+
+# |                 War Lives                   |
+# +---------------------------------------------+
+  warlives-usage:
+    # TURN INTO LIST
+    - "§cInvalid command, try: §7/wa warlives [Player Name] set [Int] or /wa warlives [Player Name] delete"
+  # {0} is the player username.
+  warlives-delete: "§e§l{0} §2war lives deleted."
+  # {0} is the town or nation name.
+  # {1} is the mobilisation amount.
+  warlives-set:  "§e§l{0} §2war lives set to §e§l{1}"

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -470,7 +470,7 @@ messages:
   # {0} is the town or nation name.
   # {1} is the war lives amount.
   # {2} is the war name.
-  warlives-set: "§e§l{0} §2war lives set to §e§l{1} §7in §e§l{2}"
+  warlives-set: "§e§l{0} §2war lives set to §e§l{1} §2in §e§l{2}"
   # {0} is the player username.
   # {1} is the war lives amount.
   # {2} is the war name.

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -466,7 +466,12 @@ messages:
     # TURN INTO LIST
     - "§cInvalid command, try: §7/wa warlives [Player Name] set [Int] or /wa warlives [Player Name] delete"
   # {0} is the player username.
-  warlives-delete: "§e§l{0} §2war lives deleted."
+  warlives-delete: "§e§l{0} §2war lives removed from §e§l{2}"
   # {0} is the town or nation name.
-  # {1} is the mobilisation amount.
-  warlives-set:  "§e§l{0} §2war lives set to §e§l{1}"
+  # {1} is the war lives amount.
+  # {2} is the war name.
+  warlives-set: "§e§l{0} §2war lives set to §e§l{1} §7in §e§l{2}"
+  # {0} is the player username.
+  # {1} is the war lives amount.
+  # {2} is the war name.
+  warlives-get: "§e§l{0} §7has §e§l{1} §2lives in §e§l{2}"


### PR DESCRIPTION
- Add war life metadata tracking (dynamically creates new data according to existing wars).
  - Supports involvement in multiple wars at once.
- Admin commands to set and delete war life metadata for specific players and wars.
- Decreases war lives when a valid enemy in the war kills you.
- If you run out of war lives you can't score pvp points or decrease enemy war lives. 