### PR TITLE
Fixed Formatting with war participants command temporarily

### DIFF
--- a/src/main/java/org/unitedlands/commands/handlers/command/town/TownWarParticipantsCommandHandler.java
+++ b/src/main/java/org/unitedlands/commands/handlers/command/town/TownWarParticipantsCommandHandler.java
@@ -67,6 +67,11 @@ public class TownWarParticipantsCommandHandler extends BaseCommandHandler {
             var town = towny.getTown(townId);
             if (town != null) {
                 String townString = town.getName();
+                if(plugin.getSiegeManager().isTownOccupied(townId)) {
+                    townString = "§r§7§m" + townString;
+                } else {
+                    townString = "§r§c" + townString;
+                }
                 if (town.hasNation()) {
                     var tag = town.getNationOrNull().getTag();
                     if (tag == null || tag.isEmpty()) {
@@ -81,6 +86,11 @@ public class TownWarParticipantsCommandHandler extends BaseCommandHandler {
             var town = towny.getTown(townId);
             if (town != null) {
                 String townString = town.getName();
+                if(plugin.getSiegeManager().isTownOccupied(townId)) {
+                    townString = "§r§7§m" + townString;
+                } else {
+                    townString = "§r§a" + townString;
+                }
                 if (town.hasNation()) {
                     var tag = town.getNationOrNull().getTag();
                     if (tag == null || tag.isEmpty()) {
@@ -107,7 +117,7 @@ public class TownWarParticipantsCommandHandler extends BaseCommandHandler {
         replacements.put("attacking-mercs", String.join(", ", attackerMercenaryNames));
         replacements.put("defending-mercs", String.join(", ", defenderMercenaryNames));
 
-        Messenger.sendMessageListTemplate(((Player) sender), "war-participants", replacements, false);
+        Messenger.sendMessageListTemplate(sender, "war-participants", replacements, false);
 
     }
 


### PR DESCRIPTION
Temporarily fixed formatting with /t war participants command, later want to reformat to remove usage of "§" and add a better setting in config